### PR TITLE
[Feature] Implement Flash Message Display After Authentication/Sign Up

### DIFF
--- a/website/templates/public/auth_base.html
+++ b/website/templates/public/auth_base.html
@@ -7,6 +7,10 @@
     <title>SoundWave</title>
   </head>
   <body>
+    {% with messages = get_flashed_messages() %} {% if messages %} {% for
+    message in messages %}
+    <div>{{ message }}</div>
+    {% endfor %} {% endif %} {% endwith %}
     <nav>
       <div class="navbar">
         <a href="/login">Login</a>

--- a/website/templates/public/home.html
+++ b/website/templates/public/home.html
@@ -7,6 +7,10 @@
     <title>SoundWave</title>
   </head>
   <body>
+    {% with messages = get_flashed_messages() %} {% if messages %} {% for
+    message in messages %}
+    <div>{{ message }}</div>
+    {% endfor %} {% endif %} {% endwith %}
     <form action="#" method="POST">
       <div>
         <label for="url">Paste the URL from YouTube video: </label>


### PR DESCRIPTION
This commit introduces a mechanism to address the issue where flash messages, crucial for notifying users, are not displayed on the page after authentication or sign-up. To enhance user experience and provide timely feedback, this feature implements a prominent display of all written flash messages following authentication or sign-up.